### PR TITLE
Custom Enum Type

### DIFF
--- a/Classes/Application/EnumDataProvider.php
+++ b/Classes/Application/EnumDataProvider.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Application;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Neos\Service\DataSource\AbstractDataSource;
+use Neos\Eel\ProtectedContextAwareInterface;
+use PackageFactory\AtomicFusion\PresentationObjects\Framework\Type\Enum;
+
+/**
+ * A universal data provider for Enums
+ */
+class EnumDataProvider extends AbstractDataSource implements ProtectedContextAwareInterface
+{
+    /**
+     * @var string
+     */
+    protected static $identifier = 'packagefactory-atomicfusion-presentationobjects-enum';
+
+    /**
+     * @param NodeInterface $node
+     * @param array $arguments
+     * @return array
+     */
+    public function getData(NodeInterface $node = null, array $arguments = []): array
+    {
+        assert(isset($arguments['enum']), new \InvalidArgumentException('Argument "enum" must be provided for EnumDataProvider.', 1600109378));
+        assert(is_subclass_of($arguments['enum'], Enum::class), new \InvalidArgumentException('Argument "enum" (' . $arguments['enum'] . ') does not refer to a class that extends ' . Enum::class . '. .', 1600109379));
+
+        /** @var Enum $enumClass */
+        $enumClass = '\\' . $arguments['enum'];
+        $enumClass::getAll();
+
+        $result = [];
+        foreach ($enumClass::getAll() as $enum) {
+            $result[$enum->getValue()]['label'] = $enum->getName();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName): bool
+    {
+        return true;
+    }
+}

--- a/Classes/Command/ComponentCommandController.php
+++ b/Classes/Command/ComponentCommandController.php
@@ -23,6 +23,7 @@ class ComponentCommandController extends CommandController
     protected $componentGenerator;
 
     /**
+     * @deprecated 2.0
      * @Flow\Inject
      * @var ValueGenerator
      */
@@ -33,6 +34,15 @@ class ComponentCommandController extends CommandController
         $this->componentGenerator->generateComponent($name, $this->request->getExceedingArguments(), $packageKey);
     }
 
+    /**
+     * @deprecated 2.0
+     * @param string $componentName
+     * @param string $name
+     * @param string $type
+     * @param array $values
+     * @param string $packageKey
+     * @return void
+     */
     public function kickStartValueCommand(string $componentName, string $name, string $type, array $values = null, string $packageKey = null): void
     {
         $this->valueGenerator->generateValue($componentName, $name, $type, $values, $packageKey);

--- a/Classes/Domain/Value/Value.php
+++ b/Classes/Domain/Value/Value.php
@@ -8,6 +8,7 @@ namespace PackageFactory\AtomicFusion\PresentationObjects\Domain\Value;
 use Neos\Flow\Annotations as Flow;
 
 /**
+ * @deprecated 2.0
  * @Flow\Proxy(false)
  */
 final class Value

--- a/Classes/Domain/Value/ValueGenerator.php
+++ b/Classes/Domain/Value/ValueGenerator.php
@@ -13,6 +13,7 @@ use PackageFactory\AtomicFusion\PresentationObjects\Domain\PackageResolver;
 /**
  * The value generator domain service
  *
+ * @deprecated 2.0
  * @Flow\Scope("singleton")
  */
 final class ValueGenerator

--- a/Classes/Framework/Type/Enum.php
+++ b/Classes/Framework/Type/Enum.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Framework\Type;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Eel\ProtectedContextAwareInterface;
+
+/**
+ * A version of spatie/enum that can be used in Eel contexts
+ */
+abstract class Enum extends \Spatie\Enum\Enum implements ProtectedContextAwareInterface
+{
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "neos/fusion": "~5.0 || dev-master",
-        "neos/flow": "~6.0 || dev-master"
+        "neos/flow": "~6.0 || dev-master",
+        "spatie/enum": "~2.3 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds a Custom Enum type based on https://github.com/spatie/enum.

The change comes in three steps:

1. Add `spatie/enum` to composer dependencies and create the custom `Enum` type
2. Create a universal `EnumDataProvider` that accepts an Enum class as an argument
3. Depcreate `kickstartValueCommand` and related value generator

**Background:**

`spatie/enum` allows to write enums like this:

```php
/**
 * @method static self REGULAR()
 * @method static self CTA()
 * @method static self SUCCESS()
 * @method static self WARNING()
 */
final class ButtonLook extends Enum
{
}
```

Thanks to the `@method` annotation, this is is fully compatible with phpStorm and Intelliphense code completion and also with phpstan static analysis. Of course, `ButtonLook` in this case remains a nominal type, which makes the picture complete.

So, basically we get all the benefits of typesafety, while having a drastically shortened syntax. The tradeoff is a Reflection-based solution, but I expect the effects of this to be negligable.

This solution is of course only supposed to live until https://wiki.php.net/rfc/enum finally lands in PHP, but as of 8.0, this does not appear to be the case.