### PR TITLE
Slots

### DIFF
--- a/Classes/Command/ComponentCommandController.php
+++ b/Classes/Command/ComponentCommandController.php
@@ -39,6 +39,7 @@ class ComponentCommandController extends CommandController
      * The following values are allowed for types:
      *
      * * string, int, float, bool
+     * * slot
      * * Value class names created with <u>component:kickstartvalue</u> in the same
      *   component namespace
      * * Component class names created with <u>component:kickstart</u> in the same

--- a/Classes/Domain/Component/PropType/PropTypeFactory.php
+++ b/Classes/Domain/Component/PropType/PropTypeFactory.php
@@ -8,6 +8,7 @@ namespace PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\PropT
 use Neos\Flow\Annotations as Flow;
 use GuzzleHttp\Psr7\Uri;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentName;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\SlotInterface;
 use Psr\Http\Message\UriInterface;
 use Sitegeist\Kaleidoscope\EelHelpers\ImageSourceHelperInterface;
 
@@ -39,6 +40,8 @@ final class PropTypeFactory
                 return new UriPropType($nullable);
             case 'ImageSource':
                 return new ImageSourcePropType($nullable);
+            case 'slot':
+                return new SlotPropType($nullable);
             default:
                 if ($isComponentArray = IsComponentArray::isSatisfiedByInputString($input)) {
                     $input = \mb_substr($input, 6, \mb_strlen($input) - 7);
@@ -80,6 +83,8 @@ final class PropTypeFactory
                     return new UriPropType($nullable);
                 case ImageSourceHelperInterface::class:
                     return new ImageSourcePropType($nullable);
+                case SlotInterface::class:
+                    return new SlotPropType($nullable);
                 default:
                     if (IsEnum::isSatisfiedByClassName($type)) {
                         /** @phpstan-var class-string<mixed> $type */

--- a/Classes/Domain/Component/PropType/SlotPropType.php
+++ b/Classes/Domain/Component/PropType/SlotPropType.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\PropType;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class SlotPropType implements PropTypeInterface
+{
+    private bool $nullable;
+
+    public function __construct(
+        bool $nullable
+    ) {
+        $this->nullable = $nullable;
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    public function getSimpleName(): string
+    {
+        return 'slot';
+    }
+
+    public function getUseStatement(): string
+    {
+        return 'use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\SlotInterface;' . PHP_EOL;
+    }
+
+    public function getType(): string
+    {
+        return ($this->nullable ? '?' : '') . 'SlotInterface';
+    }
+
+    public function getStyleGuideValue(int $nestingLevel = 0): string
+    {
+        return '= \'- Add Slot Content -\'';
+    }
+
+    public function getDefinitionData(string $propName): string
+    {
+        return '
+            <PackageFactory.AtomicFusion.PresentationObjects:Slot presentationObject={presentationObject.' . $propName . '} />
+        ';
+    }
+}

--- a/Classes/Fusion/AbstractComponentPresentationObject.php
+++ b/Classes/Fusion/AbstractComponentPresentationObject.php
@@ -5,10 +5,13 @@ namespace PackageFactory\AtomicFusion\PresentationObjects\Fusion;
  * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
  */
 
+use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentName;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\SlotInterface;
+
 /**
  * The generic abstract component presentation object implementation
  */
-abstract class AbstractComponentPresentationObject implements ComponentPresentationObjectInterface
+abstract class AbstractComponentPresentationObject implements ComponentPresentationObjectInterface, SlotInterface
 {
     /**
      * Catches all internal EEL magic calls
@@ -21,5 +24,14 @@ abstract class AbstractComponentPresentationObject implements ComponentPresentat
     final public function __call(string $name, array $arguments)
     {
         throw new \BadMethodCallException('"' . $name . '" is not part of the component API for ' . __CLASS__ . '. Please check your Fusion presentation component for typos.', 1578905708);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string
+    {
+        $componentName = ComponentName::fromClassName(static::class);
+        return $componentName->getFullyQualifiedFusionName();
     }
 }

--- a/Classes/Fusion/AbstractComponentPresentationObjectFactory.php
+++ b/Classes/Fusion/AbstractComponentPresentationObjectFactory.php
@@ -54,6 +54,7 @@ abstract class AbstractComponentPresentationObjectFactory implements ComponentPr
      * @param TraversableNodeInterface $node
      * @param PresentationObjectComponentImplementation $fusionObject
      * @return callable
+     * @deprecated since 3.0 Use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Content for content integration pusposes instead
      */
     final protected function createWrapper(TraversableNodeInterface $node, PresentationObjectComponentImplementation $fusionObject): callable
     {
@@ -70,6 +71,7 @@ abstract class AbstractComponentPresentationObjectFactory implements ComponentPr
      * @param string $propertyName
      * @param boolean $block
      * @return string
+     * @deprecated since 3.0 Use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Editable for editable property integration pusposes instead
      */
     final protected function getEditableProperty(TraversableNodeInterface $node, string $propertyName, bool $block = false): string
     {

--- a/Classes/Fusion/SelfWrapping.php
+++ b/Classes/Fusion/SelfWrapping.php
@@ -9,6 +9,7 @@ namespace PackageFactory\AtomicFusion\PresentationObjects\Fusion;
  * The trait for self-wrapping presentation components for inline editing
  *
  * The wrapper function should be created by AbstractComponentPresentationObjectFactory::createWrapper()
+ * @deprecated since 3.0 Use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Content for content integration pusposes instead
  */
 trait SelfWrapping
 {
@@ -20,6 +21,7 @@ trait SelfWrapping
     /**
      * @param string $value
      * @return string
+     * @deprecated since 3.0 Use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Content for content integration pusposes instead
      */
     final public function wrap(string $value): string
     {

--- a/Classes/Presentation/Slot/Collection.php
+++ b/Classes/Presentation/Slot/Collection.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class Collection implements CollectionInterface
+{
+    /**
+     * @var array|SlotInterface[]
+     */
+    private $items;
+
+    /**
+     * @param SlotInterface ...$items
+     */
+    private function __construct(SlotInterface ...$items)
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param iterable<mixed> $iterable
+     * @param callable|null $itemRenderer
+     * @return self
+     */
+    public static function fromIterable(iterable $iterable, ?callable $itemRenderer = null): self
+    {
+        $items = [];
+        $iteration = Iteration::fromIterable($iterable);
+        $itemRenderer = $itemRenderer ?? function ($any): ValueInterface {
+            return Value::fromAny($any);
+        };
+
+        $current = null;
+        $started = false;
+        foreach ($iterable as $key => $item) {
+            if ($started) {
+                $items[] = $itemRenderer($current[0], $current[1], $iteration);
+                $iteration = $iteration->next();
+            }
+
+            $current = [$item, $key];
+            $started = true;
+        }
+
+        if ($started) {
+            $iteration = $iteration->last();
+            $items[] = $itemRenderer($current[0], $current[1], $iteration);
+        }
+
+        return new self(...$items);
+    }
+
+    /**
+     * @param TraversableNodes<mixed> $nodes
+     * @param null|callable $itemRenderer
+     * @return self
+     */
+    public static function fromNodes(TraversableNodes $nodes, ?callable $itemRenderer = null): self
+    {
+        $itemRenderer = $itemRenderer ?? function (TraversableNodeInterface $node): ContentInterface {
+            return Content::fromNode($node);
+        };
+
+        return self::fromIterable($nodes, $itemRenderer);
+    }
+
+    /**
+     * @return array|SlotInterface[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string
+    {
+        return 'PackageFactory.AtomicFusion.PresentationObjects:Collection';
+    }
+}

--- a/Classes/Presentation/Slot/CollectionInterface.php
+++ b/Classes/Presentation/Slot/CollectionInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+interface CollectionInterface extends SlotInterface
+{
+    /**
+     * @return array|SlotInterface[]
+     */
+    public function getItems(): array;
+}

--- a/Classes/Presentation/Slot/Content.php
+++ b/Classes/Presentation/Slot/Content.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class Content implements ContentInterface
+{
+    /**
+     * @var TraversableNodeInterface
+     */
+    private $contentNode;
+
+    /**
+     * @var string
+     */
+    private $contentPrototypeName;
+
+    /**
+     * @param TraversableNodeInterface $contentNode
+     * @param string $contentPrototypeName
+     */
+    private function __construct(TraversableNodeInterface $contentNode, string $contentPrototypeName)
+    {
+        $this->contentNode = $contentNode;
+        $this->contentPrototypeName = $contentPrototypeName;
+    }
+
+    /**
+     * @param TraversableNodeInterface $node
+     * @param null|string $contentPrototypeName
+     * @return self
+     */
+    public static function fromNode(TraversableNodeInterface $node, ?string $contentPrototypeName = null): self
+    {
+        return new self($node, $contentPrototypeName ?? $node->getNodeType()->getName());
+    }
+
+    /**
+     * @return TraversableNodeInterface
+     */
+    public function getContentNode(): TraversableNodeInterface
+    {
+        return $this->contentNode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentPrototypeName(): string
+    {
+        return $this->contentPrototypeName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string
+    {
+        return 'PackageFactory.AtomicFusion.PresentationObjects:Content';
+    }
+}

--- a/Classes/Presentation/Slot/ContentInterface.php
+++ b/Classes/Presentation/Slot/ContentInterface.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+* This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+*/
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+
+interface ContentInterface extends SlotInterface
+{
+    /**
+     * @return TraversableNodeInterface
+     */
+    public function getContentNode(): TraversableNodeInterface;
+
+    /**
+     * @return string
+     */
+    public function getContentPrototypeName(): string;
+}

--- a/Classes/Presentation/Slot/Editable.php
+++ b/Classes/Presentation/Slot/Editable.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class Editable implements EditableInterface
+{
+    /**
+     * @var TraversableNodeInterface
+     */
+    private $node;
+
+    /**
+     * @var string
+     */
+    private $propertyName;
+
+    /**
+     * @var boolean
+     */
+    private $block;
+
+    /**
+     * @param TraversableNodeInterface $node
+     * @param string $propertyName
+     */
+    private function __construct(
+        TraversableNodeInterface $node,
+        string $propertyName,
+        bool $block
+    ) {
+        $this->node = $node;
+        $this->propertyName = $propertyName;
+        $this->block = $block;
+    }
+
+    /**
+     * @param TraversableNodeInterface $node
+     * @param string $propertyName
+     * @param boolean $block
+     * @return self
+     */
+    public static function fromNodeProperty(TraversableNodeInterface $node, string $propertyName, bool $block = true): self
+    {
+        return new self($node, $propertyName, $block);
+    }
+
+    /**
+     * @return TraversableNodeInterface
+     */
+    public function getNode(): TraversableNodeInterface
+    {
+        return $this->node;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getIsBlock(): bool
+    {
+        return $this->block;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string
+    {
+        return 'PackageFactory.AtomicFusion.PresentationObjects:Editable';
+    }
+}

--- a/Classes/Presentation/Slot/EditableInterface.php
+++ b/Classes/Presentation/Slot/EditableInterface.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+* This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+*/
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+
+interface EditableInterface extends SlotInterface
+{
+    /**
+     * @return TraversableNodeInterface
+     */
+    public function getNode(): TraversableNodeInterface;
+
+    /**
+     * @return string
+     */
+    public function getPropertyName(): string;
+
+    /**
+     * @return boolean
+     */
+    public function getIsBlock(): bool;
+}

--- a/Classes/Presentation/Slot/Iteration.php
+++ b/Classes/Presentation/Slot/Iteration.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class Iteration
+{
+    /**
+     * @var integer
+     */
+    private $index;
+
+    /**
+     * @var null|integer
+     */
+    private $count;
+
+    /**
+     * @var boolean
+     */
+    private $isFirst;
+
+    /**
+     * @var boolean
+     */
+    private $isLast;
+
+    /**
+     * @param integer $index
+     * @param null|integer $count
+     * @param boolean $isFirst
+     * @param boolean $isLast
+     */
+    private function __construct(
+        int $index,
+        ?int $count,
+        bool $isFirst,
+        bool $isLast
+    ) {
+        $this->index = $index;
+        $this->count = $count;
+        $this->isFirst = $isFirst;
+        $this->isLast = $isLast;
+    }
+
+    /**
+     * @param iterable<mixed> $iterable
+     * @return self
+     */
+    public static function fromIterable(iterable $iterable): self
+    {
+        return new self(
+            0,
+            is_countable($iterable) ? count($iterable) : null,
+            true,
+            false
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getCycle(): int
+    {
+        return $this->index + 1;
+    }
+
+    /**
+     * @return null|integer
+     */
+    public function getCount(): ?int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isFirst(): bool
+    {
+        return $this->isFirst;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isLast(): bool
+    {
+        return $this->isLast;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isOdd(): bool
+    {
+        return $this->getCycle() % 2 === 1;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEven(): bool
+    {
+        return $this->getCycle() % 2 === 0;
+    }
+
+    /**
+     * @return self
+     */
+    public function next(): self
+    {
+        $next = clone $this;
+        $next->index++;
+        $next->isFirst = false;
+        $next->isLast = false;
+
+        return $next;
+    }
+
+    /**
+     * @return self
+     */
+    public function last(): self
+    {
+        $next = clone $this;
+        $next->isLast = true;
+
+        return $next;
+    }
+}

--- a/Classes/Presentation/Slot/SlotInterface.php
+++ b/Classes/Presentation/Slot/SlotInterface.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+* This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+*/
+
+use PackageFactory\AtomicFusion\PresentationObjects\Fusion\ComponentPresentationObjectInterface;
+
+interface SlotInterface extends ComponentPresentationObjectInterface
+{
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string;
+}

--- a/Classes/Presentation/Slot/Value.php
+++ b/Classes/Presentation/Slot/Value.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class Value implements ValueInterface
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param string $string
+     * @return self
+     */
+    public static function fromString(string $string): self
+    {
+        return new self($string);
+    }
+
+    /**
+     * @param mixed $any
+     * @return self
+     */
+    public static function fromAny($any): self
+    {
+        return new self(self::convertToString($any));
+    }
+
+    /**
+     * @param mixed $any
+     * @return string
+     */
+    private static function convertToString($any): string
+    {
+        if (is_null($any)) {
+            return '';
+        } elseif (is_scalar($any)) {
+            return (string) $any;
+        } elseif (is_array($any)) {
+            return join('', array_map([self::class, 'convertToString'], $any));
+        } elseif (is_callable($any)) {
+            return '[callable]';
+        } elseif (is_object($any) && method_exists($any, '__toString')) {
+            return (string) $any;
+        } elseif (is_object($any)) {
+            return '[' . get_class($any) . ']';
+        } else {
+            return sprintf('[unknown type: %s]', gettype($any));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrototypeName(): string
+    {
+        return 'PackageFactory.AtomicFusion.PresentationObjects:Value';
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/Classes/Presentation/Slot/ValueInterface.php
+++ b/Classes/Presentation/Slot/ValueInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot;
+
+/*
+* This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+*/
+
+interface ValueInterface extends SlotInterface
+{
+    /**
+     * @return string
+     */
+    public function __toString(): string;
+}

--- a/Resources/Private/Fusion/Presentation/Slot/Collection.fusion
+++ b/Resources/Private/Fusion/Presentation/Slot/Collection.fusion
@@ -1,0 +1,10 @@
+prototype(PackageFactory.AtomicFusion.PresentationObjects:Collection) < prototype(PackageFactory.AtomicFusion.PresentationObjects:PresentationObjectComponent) {
+    @presentationObjectInterface = 'PackageFactory\\AtomicFusion\\PresentationObjects\\Presentation\\Slot\\SlotInterface'
+
+    renderer = Neos.Fusion:Loop {
+        items = ${presentationObject.items}
+        itemRenderer = PackageFactory.AtomicFusion.PresentationObjects:Slot {
+            presentationObject = ${item}
+        }
+    }
+}

--- a/Resources/Private/Fusion/Presentation/Slot/Content.fusion
+++ b/Resources/Private/Fusion/Presentation/Slot/Content.fusion
@@ -1,0 +1,8 @@
+prototype(PackageFactory.AtomicFusion.PresentationObjects:Content) < prototype(PackageFactory.AtomicFusion.PresentationObjects:PresentationObjectComponent) {
+    @presentationObjectInterface = 'PackageFactory\\AtomicFusion\\PresentationObjects\\Presentation\\Slot\\ContentInterface'
+
+    renderer = Neos.Fusion:Renderer {
+        @context.node = ${presentationObject.contentNode}
+        type = ${presentationObject.contentPrototypeName}
+    }
+}

--- a/Resources/Private/Fusion/Presentation/Slot/Editable.fusion
+++ b/Resources/Private/Fusion/Presentation/Slot/Editable.fusion
@@ -1,0 +1,9 @@
+prototype(PackageFactory.AtomicFusion.PresentationObjects:Editable) < prototype(PackageFactory.AtomicFusion.PresentationObjects:PresentationObjectComponent) {
+    @presentationObjectInterface = 'PackageFactory\\AtomicFusion\\PresentationObjects\\Presentation\\Slot\\EditableInterface'
+
+    renderer = Neos.Neos:Editable {
+        node = ${presentationObject.node}
+        property = ${presentationObject.propertyName}
+        block = ${presentationObject.isBlock}
+    }
+}

--- a/Resources/Private/Fusion/Presentation/Slot/Slot.fusion
+++ b/Resources/Private/Fusion/Presentation/Slot/Slot.fusion
@@ -1,0 +1,24 @@
+prototype(PackageFactory.AtomicFusion.PresentationObjects:Slot) < prototype(PackageFactory.AtomicFusion.PresentationObjects:PresentationObjectComponent) {
+    @presentationObjectInterface = 'PackageFactory\\AtomicFusion\\PresentationObjects\\Presentation\\Slot\\SlotInterface'
+
+    renderer = Neos.Fusion:Case {
+        hasPresentationObject {
+            condition = ${presentationObject.prototypeName}
+            renderer = Neos.Fusion:Renderer {
+                type = ${presentationObject.prototypeName}
+                element.presentationObject = ${presentationObject}
+            }
+        }
+
+        renderStringsInStyleguide {
+            condition = ${Type.isString(presentationObject)}
+            renderer = ${presentationObject}
+        }
+
+        fallbackForMissingPresentationObjectInStyleguide {
+            @position = 'end 9999'
+            condition = true
+            renderer = afx`<pre>- Missing Slot -</pre>`
+        }
+    }
+}

--- a/Resources/Private/Fusion/Presentation/Slot/Value.fusion
+++ b/Resources/Private/Fusion/Presentation/Slot/Value.fusion
@@ -1,0 +1,5 @@
+prototype(PackageFactory.AtomicFusion.PresentationObjects:Value) < prototype(PackageFactory.AtomicFusion.PresentationObjects:PresentationObjectComponent) {
+    @presentationObjectInterface = 'PackageFactory\\AtomicFusion\\PresentationObjects\\Presentation\\Slot\\ValueInterface'
+
+    renderer = ${String.toString(presentationObject)}
+}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,1 +1,2 @@
 include: Objects/*.fusion
+include: Presentation/**/*.fusion

--- a/Tests/Unit/Fusion/AbstractComponentPresentationObjectTest.php
+++ b/Tests/Unit/Fusion/AbstractComponentPresentationObjectTest.php
@@ -70,7 +70,7 @@ final class AbstractComponentPresentationObjectTest extends UnitTestCase
      * @test
      * @small
      * @param AbstractComponentPresentationObject $implementation
-     * @param string] $expectedPrototypeName
+     * @param string $expectedPrototypeName
      * @return void
      */
     public function implementsSlotInterfaceAndSmartlyGuessesFusionPrototypeNameFromInheritingClassNames(

--- a/Tests/Unit/Fusion/AbstractComponentPresentationObjectTest.php
+++ b/Tests/Unit/Fusion/AbstractComponentPresentationObjectTest.php
@@ -5,8 +5,15 @@ namespace PackageFactory\AtomicFusion\PresentationObjects\Tests\Unit\Fusion;
  * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
  */
 
+use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Tests\UnitTestCase;
 use PackageFactory\AtomicFusion\PresentationObjects\Fusion\AbstractComponentPresentationObject;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\SlotInterface;
+use Vendor\Site\Presentation\Component\AnotherComponent\AnotherComponent;
+use Vendor\Site\Presentation\Component\Link\Link;
+use Vendor\Site\Presentation\Component\MyComponent\MyComponent;
+use Vendor\Site\Presentation\Component\Text\Text as SiteText;
+use Vendor\Shared\Presentation\Component\Text\Text as SharedText;
 
 /**
  * Test for the AbstractComponentPresentationObject
@@ -27,5 +34,50 @@ final class AbstractComponentPresentationObjectTest extends UnitTestCase
 
         // @phpstan-ignore-next-line
         $presentationObject->getFoo();
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function presentationObjectsAndPrototypeNamesProvider(): array
+    {
+        return [
+            AnotherComponent::class => [
+                new AnotherComponent(42),
+                'Vendor.Site:Component.AnotherComponent'
+            ],
+            Link::class => [
+                new Link(new Uri('https://neos.io/'), null),
+                'Vendor.Site:Component.Link'
+            ],
+            MyComponent::class => [
+                new MyComponent('Test', new AnotherComponent(42)),
+                'Vendor.Site:Component.MyComponent'
+            ],
+            SiteText::class => [
+                new SiteText('Lorem ipsum...'),
+                'Vendor.Site:Component.Text'
+            ],
+            SharedText::class => [
+                new SharedText('Lorem ipsum...'),
+                'Vendor.Shared:Component.Text'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider presentationObjectsAndPrototypeNamesProvider
+     * @test
+     * @small
+     * @param AbstractComponentPresentationObject $implementation
+     * @param string] $expectedPrototypeName
+     * @return void
+     */
+    public function implementsSlotInterfaceAndSmartlyGuessesFusionPrototypeNameFromInheritingClassNames(
+        AbstractComponentPresentationObject $implementation,
+        string $expectedPrototypeName
+    ): void {
+        $this->assertInstanceOf(SlotInterface::class, $implementation);
+        $this->assertEquals($expectedPrototypeName, $implementation->getPrototypeName());
     }
 }

--- a/Tests/Unit/Presentation/Slot/CollectionTest.php
+++ b/Tests/Unit/Presentation/Slot/CollectionTest.php
@@ -1,0 +1,330 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Tests\Unit\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
+use Neos\Flow\Tests\UnitTestCase;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Collection;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\CollectionInterface;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ContentInterface;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Iteration;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Value;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ValueInterface;
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophet;
+
+final class CollectionTest extends UnitTestCase
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpContentTest(): void
+    {
+        $this->prophet = new Prophet();
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canBeCreatedFromIterables(): void
+    {
+        $collection = Collection::fromIterable(['Foo', 'Bar', 'Baz', 'Qux']);
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var ValueInterface[] $items */
+        $items = $collection->getItems();
+
+        $this->assertInstanceOf(ValueInterface::class, $items[0]);
+        $this->assertEquals('Foo', (string) $items[0]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[1]);
+        $this->assertEquals('Bar', (string) $items[1]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[2]);
+        $this->assertEquals('Baz', (string) $items[2]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[3]);
+        $this->assertEquals('Qux', (string) $items[3]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function allowsForCustomItemRenderingForIterables(): void
+    {
+        $collection = Collection::fromIterable(
+            ['Foo', 'Bar', 'Baz', 'Qux'],
+            function (string $item): ValueInterface {
+                return Value::fromString('(' . $item . ')');
+            }
+        );
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var ValueInterface[] $items */
+        $items = $collection->getItems();
+
+        $this->assertInstanceOf(ValueInterface::class, $items[0]);
+        $this->assertEquals('(Foo)', (string) $items[0]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[1]);
+        $this->assertEquals('(Bar)', (string) $items[1]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[2]);
+        $this->assertEquals('(Baz)', (string) $items[2]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[3]);
+        $this->assertEquals('(Qux)', (string) $items[3]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function providesIterationInfoForIterables(): void
+    {
+        $keys = [];
+        $iterations = [];
+
+        Collection::fromIterable(
+            ['Foo', 'Bar', 'Baz', 'Qux'],
+            function (string $item, int $key, Iteration $it) use (&$keys, &$iterations): ValueInterface {
+                $keys[] = $key;
+                $iterations[] = $it;
+
+                return Value::fromString('(' . $item . ')');
+            }
+        );
+
+        $this->assertCount(4, $keys);
+        $this->assertCount(4, $iterations);
+
+        $this->assertEquals(0, $keys[0]);
+        $this->assertEquals(0, $iterations[0]->getIndex());
+        $this->assertEquals(1, $iterations[0]->getCycle());
+        $this->assertEquals(4, $iterations[0]->getCount());
+        $this->assertEquals(true, $iterations[0]->isFirst());
+        $this->assertEquals(false, $iterations[0]->isLast());
+        $this->assertEquals(true, $iterations[0]->isOdd());
+        $this->assertEquals(false, $iterations[0]->isEven());
+
+        $this->assertEquals(1, $keys[1]);
+        $this->assertEquals(1, $iterations[1]->getIndex());
+        $this->assertEquals(2, $iterations[1]->getCycle());
+        $this->assertEquals(4, $iterations[1]->getCount());
+        $this->assertEquals(false, $iterations[1]->isFirst());
+        $this->assertEquals(false, $iterations[1]->isLast());
+        $this->assertEquals(false, $iterations[1]->isOdd());
+        $this->assertEquals(true, $iterations[1]->isEven());
+
+        $this->assertEquals(2, $keys[2]);
+        $this->assertEquals(2, $iterations[2]->getIndex());
+        $this->assertEquals(3, $iterations[2]->getCycle());
+        $this->assertEquals(4, $iterations[2]->getCount());
+        $this->assertEquals(false, $iterations[2]->isFirst());
+        $this->assertEquals(false, $iterations[2]->isLast());
+        $this->assertEquals(true, $iterations[2]->isOdd());
+        $this->assertEquals(false, $iterations[2]->isEven());
+
+        $this->assertEquals(3, $keys[3]);
+        $this->assertEquals(3, $iterations[3]->getIndex());
+        $this->assertEquals(4, $iterations[3]->getCycle());
+        $this->assertEquals(4, $iterations[3]->getCount());
+        $this->assertEquals(false, $iterations[3]->isFirst());
+        $this->assertEquals(true, $iterations[3]->isLast());
+        $this->assertEquals(false, $iterations[3]->isOdd());
+        $this->assertEquals(true, $iterations[3]->isEven());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canBeCreatedFromTraversableNodes(): void
+    {
+        $makeNode = function (string $nodeTypeName): ObjectProphecy {
+            $nodeType = $this->prophet->prophesize(NodeType::class);
+            $nodeType->getName()->willReturn($nodeTypeName);
+
+            $node = $this->prophet
+                ->prophesize(TraversableNodeInterface::class)
+                ->willImplement(NodeInterface::class);
+            $node->getNodeType()->willReturn($nodeType->reveal());
+
+            return $node;
+        };
+
+        $keyVisualNode = $makeNode('Vendor.Site:Content.KeyVisual');
+        $deckNode = $makeNode('Vendor.Site:Content.Deck');
+        $newletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
+
+        $nodes = TraversableNodes::fromArray([
+            $keyVisualNode->reveal(),
+            $deckNode->reveal(),
+            $newletterSubscriptionNode->reveal()
+        ]);
+
+        $collection = Collection::fromNodes($nodes);
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var ContentInterface[] $items */
+        $items = $collection->getItems();
+
+        $this->assertInstanceOf(ContentInterface::class, $items[0]);
+        $this->assertSame($keyVisualNode->reveal(), $items[0]->getContentNode());
+        $this->assertEquals('Vendor.Site:Content.KeyVisual', $items[0]->getContentPrototypeName());
+
+        $this->assertInstanceOf(ContentInterface::class, $items[1]);
+        $this->assertSame($deckNode->reveal(), $items[1]->getContentNode());
+        $this->assertEquals('Vendor.Site:Content.Deck', $items[1]->getContentPrototypeName());
+
+        $this->assertInstanceOf(ContentInterface::class, $items[2]);
+        $this->assertSame($newletterSubscriptionNode->reveal(), $items[2]->getContentNode());
+        $this->assertEquals('Vendor.Site:Content.NewsletterSubscription', $items[2]->getContentPrototypeName());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function allowsForCustomItemRenderingForTraversableNodes(): void
+    {
+        $makeNode = function (string $nodeTypeName): ObjectProphecy {
+            $nodeType = $this->prophet->prophesize(NodeType::class);
+            $nodeType->getName()->willReturn($nodeTypeName);
+
+            $node = $this->prophet
+                ->prophesize(TraversableNodeInterface::class)
+                ->willImplement(NodeInterface::class);
+            $node->getNodeType()->willReturn($nodeType->reveal());
+
+            return $node;
+        };
+
+        $keyVisualNode = $makeNode('Vendor.Site:Content.KeyVisual');
+        $deckNode = $makeNode('Vendor.Site:Content.Deck');
+        $newletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
+
+        $nodes = TraversableNodes::fromArray([
+            $keyVisualNode->reveal(),
+            $deckNode->reveal(),
+            $newletterSubscriptionNode->reveal()
+        ]);
+
+        $collection = Collection::fromNodes(
+            $nodes,
+            function (TraversableNodeInterface $node): ValueInterface {
+                return Value::fromString($node->getNodeType()->getName());
+            }
+        );
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var ValueInterface[] $items */
+        $items = $collection->getItems();
+
+        $this->assertInstanceOf(ValueInterface::class, $items[0]);
+        $this->assertEquals('Vendor.Site:Content.KeyVisual', (string) $items[0]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[1]);
+        $this->assertEquals('Vendor.Site:Content.Deck', (string) $items[1]);
+
+        $this->assertInstanceOf(ValueInterface::class, $items[2]);
+        $this->assertEquals('Vendor.Site:Content.NewsletterSubscription', (string) $items[2]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function providesIterationInfoForTraversableNodes(): void
+    {
+        $keys = [];
+        $iterations = [];
+
+        $makeNode = function (string $nodeTypeName): ObjectProphecy {
+            $nodeType = $this->prophet->prophesize(NodeType::class);
+            $nodeType->getName()->willReturn($nodeTypeName);
+
+            $node = $this->prophet
+                ->prophesize(TraversableNodeInterface::class)
+                ->willImplement(NodeInterface::class);
+            $node->getNodeType()->willReturn($nodeType->reveal());
+
+            return $node;
+        };
+
+        $keyVisualNode = $makeNode('Vendor.Site:Content.KeyVisual');
+        $deckNode = $makeNode('Vendor.Site:Content.Deck');
+        $newletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
+
+        $nodes = TraversableNodes::fromArray([
+            $keyVisualNode->reveal(),
+            $deckNode->reveal(),
+            $newletterSubscriptionNode->reveal()
+        ]);
+
+        Collection::fromNodes(
+            $nodes,
+            function (TraversableNodeInterface $node, int $key, Iteration $it) use (&$keys, &$iterations): ValueInterface {
+                $keys[] = $key;
+                $iterations[] = $it;
+
+                return Value::fromString($node->getNodeType()->getName());
+            }
+        );
+
+        $this->assertCount(3, $keys);
+        $this->assertCount(3, $iterations);
+
+        $this->assertEquals(0, $keys[0]);
+        $this->assertEquals(0, $iterations[0]->getIndex());
+        $this->assertEquals(1, $iterations[0]->getCycle());
+        $this->assertEquals(true, $iterations[0]->isFirst());
+        $this->assertEquals(false, $iterations[0]->isLast());
+        $this->assertEquals(true, $iterations[0]->isOdd());
+        $this->assertEquals(false, $iterations[0]->isEven());
+
+        $this->assertEquals(1, $keys[1]);
+        $this->assertEquals(1, $iterations[1]->getIndex());
+        $this->assertEquals(2, $iterations[1]->getCycle());
+        $this->assertEquals(false, $iterations[1]->isFirst());
+        $this->assertEquals(false, $iterations[1]->isLast());
+        $this->assertEquals(false, $iterations[1]->isOdd());
+        $this->assertEquals(true, $iterations[1]->isEven());
+
+        $this->assertEquals(2, $keys[2]);
+        $this->assertEquals(2, $iterations[2]->getIndex());
+        $this->assertEquals(3, $iterations[2]->getCycle());
+        $this->assertEquals(false, $iterations[2]->isFirst());
+        $this->assertEquals(true, $iterations[2]->isLast());
+        $this->assertEquals(true, $iterations[2]->isOdd());
+        $this->assertEquals(false, $iterations[2]->isEven());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function isRenderedAsCollectionFusionPrototype(): void
+    {
+        $collection = Collection::fromIterable([]);
+        $this->assertEquals('PackageFactory.AtomicFusion.PresentationObjects:Collection', $collection->getPrototypeName());
+    }
+}

--- a/Tests/Unit/Presentation/Slot/ContentTest.php
+++ b/Tests/Unit/Presentation/Slot/ContentTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Tests\Unit\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Content;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ContentInterface;
+use Prophecy\Prophet;
+
+final class ContentTest extends UnitTestCase
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpContentTest(): void
+    {
+        $this->prophet = new Prophet();
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function holdsInformationOnContentElements(): void
+    {
+        $contentNodeType = $this->prophet->prophesize(NodeType::class);
+        $contentNodeType->getName()->willReturn('Vendor.Site:Content.Element');
+
+        $contentNode = $this->prophet
+            ->prophesize(TraversableNodeInterface::class)
+            ->willImplement(NodeInterface::class);
+        $contentNode->getNodeType()->willReturn($contentNodeType->reveal());
+
+        $content = Content::fromNode($contentNode->reveal());
+
+        $this->assertInstanceOf(ContentInterface::class, $content);
+        $this->assertSame($contentNode->reveal(), $content->getContentNode());
+        $this->assertEquals('Vendor.Site:Content.Element', $content->getContentPrototypeName());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function allowsForCustomContentElementRendering(): void
+    {
+        $contentNode = $this->prophet
+            ->prophesize(TraversableNodeInterface::class)
+            ->willImplement(NodeInterface::class);
+        $contentNode->getNodeType()->shouldNotBeCalled();
+
+        $content = Content::fromNode($contentNode->reveal(), 'Vendor.Site:Custom.Prototype');
+
+        $this->assertInstanceOf(ContentInterface::class, $content);
+        $this->assertSame($contentNode->reveal(), $content->getContentNode());
+        $this->assertEquals('Vendor.Site:Custom.Prototype', $content->getContentPrototypeName());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function isRenderedAsContentFusionPrototype(): void
+    {
+        $contentNode = $this->prophet
+        ->prophesize(TraversableNodeInterface::class)
+        ->willImplement(NodeInterface::class);
+
+        $content = Content::fromNode($contentNode->reveal(), '');
+
+        $this->assertEquals('PackageFactory.AtomicFusion.PresentationObjects:Content', $content->getPrototypeName());
+    }
+}

--- a/Tests/Unit/Presentation/Slot/EditableTest.php
+++ b/Tests/Unit/Presentation/Slot/EditableTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Tests\Unit\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Editable;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\EditableInterface;
+use Prophecy\Prophet;
+
+final class EditableTest extends UnitTestCase
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    /**
+     * @before
+     * @return void
+     */
+    public function setUpEditableTest(): void
+    {
+        $this->prophet = new Prophet();
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function holdsInformationOnInlineEditableElements(): void
+    {
+        $contentNode1 = $this->prophet
+            ->prophesize(TraversableNodeInterface::class)
+            ->willImplement(NodeInterface::class);
+        $contentNode2 = $this->prophet
+            ->prophesize(TraversableNodeInterface::class)
+            ->willImplement(NodeInterface::class);
+
+        $editable1 = Editable::fromNodeProperty($contentNode1->reveal(), 'someProperty');
+        $editable2 = Editable::fromNodeProperty($contentNode2->reveal(), 'someOtherProperty', false);
+
+        $this->assertInstanceOf(EditableInterface::class, $editable1);
+        $this->assertSame($contentNode1->reveal(), $editable1->getNode());
+        $this->assertEquals('someProperty', $editable1->getPropertyName());
+        $this->assertEquals(true, $editable1->getIsBlock());
+
+        $this->assertInstanceOf(EditableInterface::class, $editable2);
+        $this->assertSame($contentNode2->reveal(), $editable2->getNode());
+        $this->assertEquals('someOtherProperty', $editable2->getPropertyName());
+        $this->assertEquals(false, $editable2->getIsBlock());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function isRenderedAsEditableFusionPrototype(): void
+    {
+        $contentNode = $this->prophet
+            ->prophesize(TraversableNodeInterface::class)
+            ->willImplement(NodeInterface::class);
+
+        $editable = Editable::fromNodeProperty($contentNode->reveal(), 'someProperty');
+
+        $this->assertEquals('PackageFactory.AtomicFusion.PresentationObjects:Editable', $editable->getPrototypeName());
+    }
+}

--- a/Tests/Unit/Presentation/Slot/ValueTest.php
+++ b/Tests/Unit/Presentation/Slot/ValueTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Tests\Unit\Presentation\Slot;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+use Neos\Flow\Tests\UnitTestCase;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Value;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ValueInterface;
+
+final class ValueTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function holdsStringValues(): void
+    {
+        $value = Value::fromString('Some Value');
+        $this->assertEquals('Some Value', (string) $value);
+        $this->assertInstanceOf(ValueInterface::class, $value);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function isRenderedAsValueFusionPrototype(): void
+    {
+        $value = Value::fromString('Some Value');
+        $this->assertEquals('PackageFactory.AtomicFusion.PresentationObjects:Value', $value->getPrototypeName());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function inputValueProvider(): array
+    {
+        if ($resource = fopen('/dev/null', 'r')) {
+            fclose($resource);
+        }
+
+        return [
+            'null' =>
+                [null, ''],
+            'array of strings' =>
+                [['Hello', 'World'], 'HelloWorld'],
+            'array of integers' =>
+                [[1, 2, 3, 4], '1234'],
+            'array of floats' =>
+                [[3.14,42.23], '3.1442.23'],
+            'callable' =>
+                [function () {
+                }, '[callable]'],
+            'object with __toString method' =>
+                [new class {
+                    public function __toString(): string
+                    {
+                        return 'Hello Object!';
+                    }
+                }, 'Hello Object!'],
+            'object without __toString method' =>
+                [new \stdClass, '[stdClass]'],
+            'resource' =>
+                [$resource, '[unknown type: resource (closed)]'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider inputValueProvider
+     * @param mixed $inputValue
+     * @param string $expectedString
+     * @return void
+     */
+    public function canbeCreatedFromAnyInputValue($inputValue, $expectedString): void
+    {
+        $value = Value::fromAny($inputValue);
+
+        $this->assertInstanceOf(ValueInterface::class, $value);
+        $this->assertEquals($expectedString, (string) $value);
+    }
+}


### PR DESCRIPTION
This PR introduces the concept of slots.

**There's a demo available at:** https://github.com/grebaldi/presentationobjects-slots-demo

## SlotInterface, Content, Collection, Editable, Value

A Slot represents an instruction for Fusion to render a given prototype. It can be used for indirect rendering, similar to `Neos.Fusion:Renderer`.

The idea is loosely based on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot.

A component uses a slot like this:

```fusion
prototype(Vendor.Site:Button) < prototype(PresentationObjectComponent) {
    @presentationObjectInterface = 'Vendor\\Site\\Presentation\\Block\\Button\\ButtonInterface'

    renderer = afx`
        <button type={props.model.type}>
            <PackageFactory.AtomicFusion.PresentationObjects:Slot model={presentationObject.label}/>
        </button>
    `
}
```

The model's interface then looks like this:

```php
final class Button implements ButtonInterface
{
    /**
     * @param ButtonVariant $variant
     * @param ButtonType $type
     * @param HorizontalAlignment $horizontalAlignment
     * @param string $title
     * @param SlotInterface $label
     */
    public function __construct(
        ButtonVariant $variant,
        ButtonType $type,
        HorizontalAlignment $horizontalAlignment,
        string $title,
        SlotInterface $label
    ) {
        $this->variant = $variant;
        $this->type = $type;
        $this->horizontalAlignment = $horizontalAlignment;
        $this->title = $title;
        $this->label = $label;
    }

   // ...
}
```

Now any presentation model that implements `SlotInterface` can be rendered as a button label, without an extra fusion roundtrip.

To provide for basic needs in Neos projects, some default models are provided, namely:

### Content

Content takes a `TraversableNodeInterface` and a `contentPrototypeName` and redirects rendering inside Fusion to the latter. It essentially replaces the need for the `SelfWrapping` concept.

In Factories, it can be initialized via static factory method:

```php
Content::fromNode($node, $contentPrototypeName)
```

`$contentPrototypeName` is optional. By default, `$node->getNodeType()->getName()` is used, similar to `Neos.Neos:ContentCase`.

### Collection

Collection is a Wrapper for `Neos.Fusion:Loop` and simply joins an array of `SlotInterface`s.

In Factories, it can be initialized via static factory method, taking `TraversableNodes` as its first argument:

```php
Collection::fromNodes($nodes, function (TraversableNodeInterface $node, int $key, Iteration $iteration): SlotInterface {
    // ...
});
```

The second argument is optional. By default, rendering will be directed through `Content` using `$node->getNodeType()->getName()` as the rendering prototype name for each item.

### Value

Value wraps any given php value into a `SlotInterface` and sees through that it is properly stringified - thus saving us the headache of the good ol' dreadful `Array to string conversion`-Exception forever.

In Factories, it can be initialized via static factory method:

```php
Value::fromAny($anything)
```

### Editable

Editable takes a `TraversableNodeInterface`, a `propertyName` and the flag `isBlock`. It redirects rendering to the `Neos.Neos:Editable` node type and thus essentially replaces the protected method `getEditableProperty` currently present in all Factories.

In Factories, it can be initialized via static factory method:

```php
Editable::fromNodeProperty($node, 'somePropertyName', false);
```

The third argument is optional. By default, it's set to `true` which is dissimilar to `getEditableProperty`, but matches the default of `Neos.Neos:Editable`.

## TODOs

- [ ] Add documentation
- [x] If greenlit, add deprecation notices to `getEditableProperty` and all `SelfWrapping`-related code