### PR TITLE
Add FileWriter

### DIFF
--- a/Classes/Command/ComponentCommandController.php
+++ b/Classes/Command/ComponentCommandController.php
@@ -49,6 +49,7 @@ class ComponentCommandController extends CommandController
      *
      * @param string $name The name of the new component
      * @param bool $listable If set, an additional list type will be generated
+     * @param bool $yes If set, no confirmation is going to be required for overwriting files
      * @return void
      * @throws \Neos\Utility\Exception\FilesException
      */
@@ -82,6 +83,7 @@ class ComponentCommandController extends CommandController
      * @param string $name The name of the new pseudo-enum
      * @param string $type The type of the new pseudo-enum (must be one of: "string", "int")
      * @param array|string[] $values A comma-separated colon list of names:values for the new pseudo-enum, e.g. a,b,c , a:1,b:2,c:3 or a:1.2,b:2.4,c:3.6
+     * @param bool $yes If set, no confirmation is going to be required for overwriting files
      * @return void
      */
     public function kickStartEnumCommand(string $componentName, string $name, string $type, array $values = [], bool $yes = false): void

--- a/Classes/Command/ComponentCommandController.php
+++ b/Classes/Command/ComponentCommandController.php
@@ -12,6 +12,7 @@ use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentNa
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\Enum\EnumGenerator;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\PackageKey;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\PackageResolver;
+use PackageFactory\AtomicFusion\PresentationObjects\Infrastructure\DefensiveConfirmationFileWriter;
 
 /**
  * The command controller for kick-starting PresentationObject components
@@ -23,18 +24,6 @@ class ComponentCommandController extends CommandController
      * @var PackageResolver
      */
     protected $packageResolver;
-
-    /**
-     * @Flow\Inject
-     * @var ComponentGenerator
-     */
-    protected $componentGenerator;
-
-    /**
-     * @Flow\Inject
-     * @var EnumGenerator
-     */
-    protected $valueGenerator;
 
     /**
      * Create a new PresentationObject component and factory
@@ -63,10 +52,14 @@ class ComponentCommandController extends CommandController
      * @return void
      * @throws \Neos\Utility\Exception\FilesException
      */
-    public function kickStartCommand(string $name, bool $listable = false): void
+    public function kickStartCommand(string $name, bool $listable = false, bool $yes = false): void
     {
+        $componentGenerator = new ComponentGenerator(
+            new DefensiveConfirmationFileWriter($this->output, $yes)
+        );
         $package = $this->packageResolver->resolvePackage();
-        $this->componentGenerator->generateComponent(
+
+        $componentGenerator->generateComponent(
             ComponentName::fromInput($name, PackageKey::fromPackage($package)),
             $this->request->getExceedingArguments(),
             $package->getPackagePath(),
@@ -91,10 +84,15 @@ class ComponentCommandController extends CommandController
      * @param array|string[] $values A comma-separated colon list of names:values for the new pseudo-enum, e.g. a,b,c , a:1,b:2,c:3 or a:1.2,b:2.4,c:3.6
      * @return void
      */
-    public function kickStartEnumCommand(string $componentName, string $name, string $type, array $values = []): void
+    public function kickStartEnumCommand(string $componentName, string $name, string $type, array $values = [], bool $yes = false): void
     {
+        $enumGenerator = new EnumGenerator(
+            new \DateTimeImmutable(),
+            new DefensiveConfirmationFileWriter($this->output, $yes)
+        );
         $package = $this->packageResolver->resolvePackage();
-        $this->valueGenerator->generateEnum(
+
+        $enumGenerator->generateEnum(
             ComponentName::fromInput($componentName, PackageKey::fromPackage($package)),
             $name,
             $type,

--- a/Classes/Domain/FileWriterInterface.php
+++ b/Classes/Domain/FileWriterInterface.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Domain;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package
+ */
+
+interface FileWriterInterface
+{
+    /**
+     * @param string $filePath
+     * @param string $fileContents
+     * @return void
+     */
+    public function writeFile(string $filePath, string $fileContents): void;
+}

--- a/Classes/Infrastructure/DefensiveConfirmationFileWriter.php
+++ b/Classes/Infrastructure/DefensiveConfirmationFileWriter.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Infrastructure;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Flow\Cli\ConsoleOutput;
+use Neos\Utility\Files;
+use PackageFactory\AtomicFusion\PresentationObjects\Domain\FileWriterInterface;
+
+final class DefensiveConfirmationFileWriter implements FileWriterInterface
+{
+    private ConsoleOutput $output;
+
+    private bool $assumeYes;
+
+    public function __construct(ConsoleOutput $output, bool $assumeYes)
+    {
+        $this->output = $output;
+        $this->assumeYes = $assumeYes;
+    }
+
+    public function writeFile(string $filePath, string $fileContents): void
+    {
+        $dirname = dirname($filePath);
+
+        if (!file_exists($dirname)) {
+            Files::createDirectoryRecursively($dirname);
+        }
+
+        if (!is_dir($dirname)) {
+            $this->output->outputLine(
+                '<error>Could not write file: %s</error>',
+                [$filePath]
+            );
+            $this->output->outputLine(
+                '"%s" is not a directory!',
+                [$dirname]
+            );
+            return;
+        }
+
+        if (file_exists($filePath) && !$this->assumeYes) {
+            $this->output->output(
+                'Overwrite <b>"%s"</b>? (y/N)',
+                [$this->localizeFilePath($filePath)]
+            );
+
+            if (!$this->output->askConfirmation(' ', false)) {
+                return;
+            }
+        }
+
+        file_put_contents($filePath, $fileContents);
+        $this->output->outputLine(
+            'File <success><b>"%s"</b></success> was written.',
+            [$this->localizeFilePath($filePath)]
+        );
+    }
+
+    protected function localizeFilePath(string $filePath): string
+    {
+        $localizedPath = $filePath;
+        if (\mb_substr($localizedPath, 0, \mb_strlen(FLOW_PATH_ROOT)) == FLOW_PATH_ROOT) {
+            $localizedPath = substr($localizedPath, strlen(FLOW_PATH_ROOT));
+        }
+
+        return implode('/', array_filter(explode('/', $localizedPath)));
+    }
+}

--- a/Classes/Infrastructure/SimpleFileWriter.php
+++ b/Classes/Infrastructure/SimpleFileWriter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+namespace PackageFactory\AtomicFusion\PresentationObjects\Infrastructure;
+
+/*
+ * This file is part of the PackageFactory.AtomicFusion.PresentationObjects package.
+ */
+
+use Neos\Utility\Files;
+use PackageFactory\AtomicFusion\PresentationObjects\Domain\FileWriterInterface;
+
+final class SimpleFileWriter implements FileWriterInterface
+{
+    public function writeFile(string $filePath, string $fileContents): void
+    {
+        $dirname = dirname($filePath);
+
+        if (!file_exists($dirname)) {
+            Files::createDirectoryRecursively($dirname);
+        }
+
+        file_put_contents($filePath, $fileContents);
+    }
+}

--- a/Tests/Unit/Domain/Component/ComponentGeneratorTest.php
+++ b/Tests/Unit/Domain/Component/ComponentGeneratorTest.php
@@ -11,6 +11,7 @@ use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentGe
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentName;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\FusionNamespace;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\PackageKey;
+use PackageFactory\AtomicFusion\PresentationObjects\Infrastructure\SimpleFileWriter;
 use Spatie\Snapshots\MatchesSnapshots;
 
 /**
@@ -45,7 +46,9 @@ final class ComponentGeneratorTest extends UnitTestCase
             ],
         ]);
 
-        $this->componentGenerator = new ComponentGenerator();
+        $this->componentGenerator = new ComponentGenerator(
+            new SimpleFileWriter()
+        );
     }
 
     /**

--- a/Tests/Unit/Domain/Enum/EnumGeneratorTest.php
+++ b/Tests/Unit/Domain/Enum/EnumGeneratorTest.php
@@ -11,6 +11,7 @@ use PackageFactory\AtomicFusion\PresentationObjects\Domain\Component\ComponentNa
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\FusionNamespace;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\Enum\EnumGenerator;
 use PackageFactory\AtomicFusion\PresentationObjects\Domain\PackageKey;
+use PackageFactory\AtomicFusion\PresentationObjects\Infrastructure\SimpleFileWriter;
 use Spatie\Snapshots\MatchesSnapshots;
 
 /**
@@ -36,7 +37,10 @@ final class EnumGeneratorTest extends UnitTestCase
             'Vendor.Default' => [],
         ]);
 
-        $this->enumGenerator = new EnumGenerator(new \DateTimeImmutable('@1602423895'));
+        $this->enumGenerator = new EnumGenerator(
+            new \DateTimeImmutable('@1602423895'),
+            new SimpleFileWriter()
+        );
     }
 
     /**

--- a/phpstan.bootstrap.php
+++ b/phpstan.bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+define('FLOW_PATH_ROOT', '');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
 		- Packages/Framework/Neos.Flow/Tests/FunctionalTestCase.php
 		- Tests/Unit/Fixtures/Site/Presentation/Component/MyReflectionComponent/MyReflectionComponent.php
 		- Tests/Unit/Fixtures/Site/Presentation/Component/MyNewComponent/MyStringEnum.php
+		- phpstan.bootstrap.php
 	excludes_analyse:
 		- Tests/Unit/Helper/*
 		- Tests/Unit/Fixtures/*


### PR DESCRIPTION
This PR adds a `FileWriterInterface` that is used to intercept all file system write operations during component or enum generation.

It also add a `DefensiveConfirmationFileWriter` that is used in the `ComponentCommandController`. This specialized file writer will print the written file paths to the console and will also ask for confirmation, when files are about to be overwritten, giving the user a chance to prevent that from happening.