### PR TITLE
Adjust default itemRenderer in Collection:fromIterable

### DIFF
--- a/Classes/Presentation/Slot/Collection.php
+++ b/Classes/Presentation/Slot/Collection.php
@@ -36,13 +36,22 @@ final class Collection implements CollectionInterface
     {
         $items = [];
         $iteration = Iteration::fromIterable($iterable);
-        $itemRenderer = $itemRenderer ?? function ($any): ValueInterface {
+        $itemRenderer = $itemRenderer ?? function ($any): ?SlotInterface {
+            if (is_null($any)) {
+                return null;
+            } elseif ($any instanceof SlotInterface) {
+                return $any;
+            }
             return Value::fromAny($any);
         };
 
+        /** @var array<int,mixed> $current */
         $current = null;
         $started = false;
         foreach ($iterable as $key => $item) {
+            if (is_null($item)) {
+                continue;
+            }
             if ($started) {
                 $items[] = $itemRenderer($current[0], $current[1], $iteration);
                 $iteration = $iteration->next();

--- a/Tests/Unit/Presentation/Slot/CollectionTest.php
+++ b/Tests/Unit/Presentation/Slot/CollectionTest.php
@@ -14,10 +14,13 @@ use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Collection
 use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\CollectionInterface;
 use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ContentInterface;
 use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Iteration;
+use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\SlotInterface;
 use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\Value;
 use PackageFactory\AtomicFusion\PresentationObjects\Presentation\Slot\ValueInterface;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
+use Vendor\Site\Presentation\Component\Text\Text;
+use Vendor\Site\Presentation\Component\Text\TextInterface;
 
 final class CollectionTest extends UnitTestCase
 {
@@ -155,6 +158,55 @@ final class CollectionTest extends UnitTestCase
      * @test
      * @return void
      */
+    public function keepsSlotsInIterables(): void
+    {
+        $collection = Collection::fromIterable(
+            [new Text('Text')]
+        );
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var array<int,TextInterface> $items */
+        $items = $collection->getItems();
+
+        $this->assertInstanceOf(Text::class, $items[0]);
+        $this->assertEquals('Text', $items[0]->getText());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function acceptsButRemovesNullValuesInIterables(): void
+    {
+        $collection = Collection::fromIterable([
+            new Text('Text'),
+            null,
+            'Foo'
+        ]);
+
+        $this->assertInstanceOf(CollectionInterface::class, $collection);
+
+        /** @var array<int,SlotInterface> $items */
+        $items = $collection->getItems();
+
+        $this->assertSame(2, count($items));
+
+        $firstItem = $items[0];
+        $this->assertInstanceOf(Text::class, $firstItem);
+        /** @var Text $firstItem */
+        $this->assertEquals('Text', $firstItem->getText());
+
+        $secondItem = $items[1];
+        $this->assertInstanceOf(ValueInterface::class, $secondItem);
+        /** @var ValueInterface $secondItem */
+        $this->assertEquals('Foo', (string) $secondItem);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
     public function canBeCreatedFromTraversableNodes(): void
     {
         $makeNode = function (string $nodeTypeName): ObjectProphecy {
@@ -171,12 +223,12 @@ final class CollectionTest extends UnitTestCase
 
         $keyVisualNode = $makeNode('Vendor.Site:Content.KeyVisual');
         $deckNode = $makeNode('Vendor.Site:Content.Deck');
-        $newletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
+        $newsletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
 
         $nodes = TraversableNodes::fromArray([
             $keyVisualNode->reveal(),
             $deckNode->reveal(),
-            $newletterSubscriptionNode->reveal()
+            $newsletterSubscriptionNode->reveal()
         ]);
 
         $collection = Collection::fromNodes($nodes);
@@ -195,7 +247,7 @@ final class CollectionTest extends UnitTestCase
         $this->assertEquals('Vendor.Site:Content.Deck', $items[1]->getContentPrototypeName());
 
         $this->assertInstanceOf(ContentInterface::class, $items[2]);
-        $this->assertSame($newletterSubscriptionNode->reveal(), $items[2]->getContentNode());
+        $this->assertSame($newsletterSubscriptionNode->reveal(), $items[2]->getContentNode());
         $this->assertEquals('Vendor.Site:Content.NewsletterSubscription', $items[2]->getContentPrototypeName());
     }
 
@@ -219,12 +271,12 @@ final class CollectionTest extends UnitTestCase
 
         $keyVisualNode = $makeNode('Vendor.Site:Content.KeyVisual');
         $deckNode = $makeNode('Vendor.Site:Content.Deck');
-        $newletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
+        $newsletterSubscriptionNode = $makeNode('Vendor.Site:Content.NewsletterSubscription');
 
         $nodes = TraversableNodes::fromArray([
             $keyVisualNode->reveal(),
             $deckNode->reveal(),
-            $newletterSubscriptionNode->reveal()
+            $newsletterSubscriptionNode->reveal()
         ]);
 
         $collection = Collection::fromNodes(


### PR DESCRIPTION
This will keep SlotInterface elements instead of replacing them by Value
(identity function).
It also allows for null value in iterables, which are later filtered out