### PR TITLE
BUGFIX: Ensure compatibility with PHP 8.1 and Neos 8

### DIFF
--- a/Classes/Domain/Enum/EnumGenerator.php
+++ b/Classes/Domain/Enum/EnumGenerator.php
@@ -20,7 +20,7 @@ final class EnumGenerator
 
     private FileWriterInterface $fileWriter;
 
-    public function __construct(?\DateTimeImmutable $now = null, FileWriterInterface $fileWriter)
+    public function __construct(?\DateTimeImmutable $now, FileWriterInterface $fileWriter)
     {
         $this->now = $now ?? new \DateTimeImmutable();
         $this->fileWriter = $fileWriter;

--- a/Tests/Unit/Fusion/PresentationObjectComponentImplementationTest.php
+++ b/Tests/Unit/Fusion/PresentationObjectComponentImplementationTest.php
@@ -63,6 +63,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
             ->getCurrentContext()
             ->willReturn([]);
         $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
+        $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(true);
         $runtime
@@ -94,6 +97,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
         $runtime
             ->getCurrentContext()
             ->willReturn([]);
+        $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
         $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);
@@ -159,6 +165,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
             ->getCurrentContext()
             ->willReturn([]);
         $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
+        $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);
         $runtime
@@ -188,6 +197,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
         $runtime
             ->getCurrentContext()
             ->willReturn([]);
+        $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
         $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);
@@ -222,6 +234,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
             ->getCurrentContext()
             ->willReturn([]);
         $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
+        $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);
         $runtime
@@ -255,6 +270,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
             ->getCurrentContext()
             ->willReturn([]);
         $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
+        $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);
         $runtime
@@ -287,6 +305,9 @@ class PresentationObjectComponentImplementationTest extends UnitTestCase
         $runtime
             ->getCurrentContext()
             ->willReturn([]);
+        $runtime
+            ->evaluate('test/__meta/sortProperties', $subject)
+            ->willReturn(true);
         $runtime
             ->evaluate('test/' . PresentationObjectComponentImplementation::PREVIEW_MODE, $subject)
             ->willReturn(false);

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ~8.0.0",
         "neos/neos": "^5.0 || ^7.0 || dev-master",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "sitegeist/kaleidoscope": "^5.0 || ^6.0 || dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "neos/neos": "^5.0 || ^7.0 || dev-master",
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "neos/neos": "^5.0 || ^7.0 || ^8.0 || dev-master",
         "sitegeist/kaleidoscope": "^5.0 || ^6.0 || dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
fixes: #26, #27 

Description's in the title :D

I tested with PHP 8.1 and Neos 8.2 and found no issues.

Unit tests were mad at me, because the implementation of `AbstractArrayFusionObject::sortNestedFusionKeys` has changed in a way that confused `Prophecy\Prophet` (leaky implementation detail). I therefore do not expect that the changed test will run with anything below Neos 8, but for now, our automated tests would fetch Neos 8 anyway.